### PR TITLE
BBCode support

### DIFF
--- a/build/package/binaries
+++ b/build/package/binaries
@@ -76,7 +76,6 @@ createRelease() {
 }
 
 # Mac Releases
-createRelease darwin 386
 createRelease darwin amd64
 
 # PowerPC Releases

--- a/cmd/dropbox-gif-linker/dropbox-gif-linker.go
+++ b/cmd/dropbox-gif-linker/dropbox-gif-linker.go
@@ -30,6 +30,10 @@ func md() bool {
 	return mode == "md"
 }
 
+func bbcode() bool {
+	return mode == "bbcode"
+}
+
 func handleFirstArg(argument string) {
 	if os.Args[1] == "version" || os.Args[1] == "--version" {
 		fmt.Println(version.Full())
@@ -91,6 +95,9 @@ func capture(gifRecord gifkv.Record) {
 		if md() {
 			fmt.Println(messages.LinkTextNew(gifRecord.Markdown()))
 			clipboard.Write(gifRecord.Markdown())
+		} else if bbcode() {
+			fmt.Println(messages.LinkTextNew(gifRecord.BBCode()))
+			clipboard.Write(gifRecord.BBCode())
 		} else {
 			fmt.Println(messages.LinkTextNew(gifRecord.URL()))
 			clipboard.Write(gifRecord.URL())
@@ -124,6 +131,10 @@ func handleCommand(input string, gifRecord gifkv.Record) bool {
 	} else if commands.MarkdownMode(input) {
 		mode = "md"
 		fmt.Println(messages.ModeShift("md"))
+		capture(gifRecord)
+	} else if commands.BBCodeMode(input) {
+		mode = "bbcode"
+		fmt.Println(messages.ModeShift("bbcode"))
 		capture(gifRecord)
 	} else if commands.Help(input) {
 		fmt.Println(messages.Help(helpMessage()))

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/trueheart78/dropbox-gif-linker
 
+go 1.15
+
 require (
 	github.com/atotto/clipboard v0.1.0
 	github.com/bclicn/color v0.0.0-20161123064900-4c02eff8a28c

--- a/internal/pkg/commands/commands.go
+++ b/internal/pkg/commands/commands.go
@@ -31,8 +31,8 @@ func MarkdownMode(input string) bool {
 	return supported(input, markdownCommands[:])
 }
 
-// BbcodeMode returns true if the input is a bbcode mode command
-func BbcodeMode(input string) bool {
+// BBCodeMode returns true if the input is a bbcode mode command
+func BBCodeMode(input string) bool {
 	return supported(input, bbcodeCommands[:])
 }
 

--- a/internal/pkg/commands/commands.go
+++ b/internal/pkg/commands/commands.go
@@ -8,6 +8,7 @@ import (
 var exitCommands = [4]string{"exit", "e", "quit", "q"}
 var urlCommands = [2]string{"url", "u"}
 var markdownCommands = [2]string{"md", "m"}
+var bbcodeCommands = [2]string{"bbcode", "b"}
 var deleteCommands = [2]string{"delete", "del"}
 var configCommands = [2]string{"config", "details"}
 var countCommands = [2]string{"count", "gifs"}
@@ -28,6 +29,11 @@ func URLMode(input string) (exists bool) {
 // MarkdownMode returns true if the input is a markdown mode command
 func MarkdownMode(input string) bool {
 	return supported(input, markdownCommands[:])
+}
+
+// BbcodeMode returns true if the input is a bbcode mode command
+func BbcodeMode(input string) bool {
+	return supported(input, bbcodeCommands[:])
 }
 
 // Delete returns true if the input is a delete command
@@ -69,6 +75,9 @@ func Any(input string) bool {
 	for _, v := range markdownCommands {
 		all = append(all, v)
 	}
+	for _, v := range bbcodeCommands {
+		all = append(all, v)
+	}
 	for _, v := range deleteCommands {
 		all = append(all, v)
 	}
@@ -99,6 +108,7 @@ func HelpOutput() string {
 	output := "Supported Commands:\n"
 	output += fmt.Sprintf(" %v - Shift to URL Mode\n", strings.Join(urlCommands[:], ", "))
 	output += fmt.Sprintf(" %v - Shift to Markdown Mode\n", strings.Join(markdownCommands[:], ", "))
+	output += fmt.Sprintf(" %v - Shift to BBCode Mode\n", strings.Join(bbcodeCommands[:], ", "))
 	output += fmt.Sprintf(" %v - Delete Last Record\n", strings.Join(deleteCommands[:], ", "))
 	output += fmt.Sprintf(" %v - Database Record Count\n", strings.Join(countCommands[:], ", "))
 	output += fmt.Sprintf(" %v - Loaded Configuration\n", strings.Join(configCommands[:], ", "))

--- a/internal/pkg/commands/commands_test.go
+++ b/internal/pkg/commands/commands_test.go
@@ -11,6 +11,7 @@ func TestSupportedCommands(t *testing.T) {
 	assert.Equal(t, [4]string{"exit", "e", "quit", "q"}, exitCommands)
 	assert.Equal(t, [2]string{"url", "u"}, urlCommands)
 	assert.Equal(t, [2]string{"md", "m"}, markdownCommands)
+	assert.Equal(t, [2]string{"bbcode", "b"}, bbcodeCommands)
 	assert.Equal(t, [2]string{"delete", "del"}, deleteCommands)
 	assert.Equal(t, [2]string{"version", "v"}, versionCommands)
 	assert.Equal(t, [2]string{"help", "?"}, helpCommands)
@@ -32,6 +33,7 @@ func TestExit(t *testing.T) {
 
 	assert.False(Exit("url"))
 	assert.False(Exit("md"))
+	assert.False(Exit("bbcode"))
 	assert.False(Exit("delete"))
 	assert.False(Exit("config"))
 	assert.False(Exit("help"))
@@ -49,6 +51,7 @@ func TestURLMode(t *testing.T) {
 	assert.True(URLMode(":u"))
 
 	assert.False(URLMode("md"))
+	assert.False(URLMode("bbcode"))
 	assert.False(URLMode("exit"))
 	assert.False(URLMode("delete"))
 	assert.False(URLMode("config"))
@@ -67,6 +70,7 @@ func TestMarkdownMode(t *testing.T) {
 	assert.True(MarkdownMode(":m"))
 
 	assert.False(MarkdownMode("url"))
+	assert.False(MarkdownMode("bbcode"))
 	assert.False(MarkdownMode("exit"))
 	assert.False(MarkdownMode("delete"))
 	assert.False(MarkdownMode("config"))
@@ -74,6 +78,25 @@ func TestMarkdownMode(t *testing.T) {
 	assert.False(MarkdownMode("count"))
 	assert.False(MarkdownMode("version"))
 	assert.False(MarkdownMode("taylor"))
+}
+
+func TestBbcodeMode(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.True(BbcodeMode("bbcode"))
+	assert.True(BbcodeMode("b"))
+	assert.True(BbcodeMode(":bbcode"))
+	assert.True(BbcodeMode(":b"))
+
+	assert.False(BbcodeMode("url"))
+	assert.False(BbcodeMode("md"))
+	assert.False(BbcodeMode("exit"))
+	assert.False(BbcodeMode("delete"))
+	assert.False(BbcodeMode("config"))
+	assert.False(BbcodeMode("help"))
+	assert.False(BbcodeMode("count"))
+	assert.False(BbcodeMode("version"))
+	assert.False(BbcodeMode("taylor"))
 }
 
 func TestDelete(t *testing.T) {
@@ -86,6 +109,7 @@ func TestDelete(t *testing.T) {
 
 	assert.False(Delete("url"))
 	assert.False(Delete("md"))
+	assert.False(Delete("bbcode"))
 	assert.False(Delete("help"))
 	assert.False(Delete("exit"))
 	assert.False(Delete("config"))
@@ -104,6 +128,7 @@ func TestHelp(t *testing.T) {
 
 	assert.False(Help("url"))
 	assert.False(Help("md"))
+	assert.False(Help("bbcode"))
 	assert.False(Help("exit"))
 	assert.False(Help("delete"))
 	assert.False(Help("config"))
@@ -120,6 +145,7 @@ func TestConfig(t *testing.T) {
 
 	assert.False(Config("url"))
 	assert.False(Config("md"))
+	assert.False(Config("bbcode"))
 	assert.False(Config("help"))
 	assert.False(Config("delete"))
 	assert.False(Config("exit"))
@@ -135,6 +161,7 @@ func TestCount(t *testing.T) {
 
 	assert.False(Count("url"))
 	assert.False(Count("md"))
+	assert.False(Count("bbcode"))
 	assert.False(Count("help"))
 	assert.False(Count("delete"))
 	assert.False(Count("exit"))
@@ -150,6 +177,7 @@ func TestVersion(t *testing.T) {
 
 	assert.False(Version("url"))
 	assert.False(Version("md"))
+	assert.False(Version("bbcode"))
 	assert.False(Version("help"))
 	assert.False(Version("delete"))
 	assert.False(Version("exit"))
@@ -165,6 +193,7 @@ func TestTaylor(t *testing.T) {
 
 	assert.False(Taylor("url"))
 	assert.False(Taylor("md"))
+	assert.False(Taylor("bbcode"))
 	assert.False(Taylor("help"))
 	assert.False(Taylor("delete"))
 	assert.False(Taylor("exit"))
@@ -176,6 +205,7 @@ func TestTaylor(t *testing.T) {
 func TestAny(t *testing.T) {
 	assert.True(t, Any("url"))
 	assert.True(t, Any("md"))
+	assert.True(t, Any("bbcode"))
 	assert.True(t, Any("help"))
 	assert.True(t, Any("delete"))
 	assert.True(t, Any("exit"))

--- a/internal/pkg/commands/commands_test.go
+++ b/internal/pkg/commands/commands_test.go
@@ -80,23 +80,23 @@ func TestMarkdownMode(t *testing.T) {
 	assert.False(MarkdownMode("taylor"))
 }
 
-func TestBbcodeMode(t *testing.T) {
+func TestBBCodeMode(t *testing.T) {
 	assert := assert.New(t)
 
-	assert.True(BbcodeMode("bbcode"))
-	assert.True(BbcodeMode("b"))
-	assert.True(BbcodeMode(":bbcode"))
-	assert.True(BbcodeMode(":b"))
+	assert.True(BBCodeMode("bbcode"))
+	assert.True(BBCodeMode("b"))
+	assert.True(BBCodeMode(":bbcode"))
+	assert.True(BBCodeMode(":b"))
 
-	assert.False(BbcodeMode("url"))
-	assert.False(BbcodeMode("md"))
-	assert.False(BbcodeMode("exit"))
-	assert.False(BbcodeMode("delete"))
-	assert.False(BbcodeMode("config"))
-	assert.False(BbcodeMode("help"))
-	assert.False(BbcodeMode("count"))
-	assert.False(BbcodeMode("version"))
-	assert.False(BbcodeMode("taylor"))
+	assert.False(BBCodeMode("url"))
+	assert.False(BBCodeMode("md"))
+	assert.False(BBCodeMode("exit"))
+	assert.False(BBCodeMode("delete"))
+	assert.False(BBCodeMode("config"))
+	assert.False(BBCodeMode("help"))
+	assert.False(BBCodeMode("count"))
+	assert.False(BBCodeMode("version"))
+	assert.False(BBCodeMode("taylor"))
 }
 
 func TestDelete(t *testing.T) {

--- a/internal/pkg/gifkv/gifkv.go
+++ b/internal/pkg/gifkv/gifkv.go
@@ -165,6 +165,11 @@ func (r Record) Markdown() string {
 	return fmt.Sprintf("![%v](%v)", r.BaseName, r.URL())
 }
 
+// BBCode returns a publicly-accessible bbcode-based url
+func (r Record) BBCode() string {
+	return fmt.Sprintf("[img]%v[/img]", r.URL())
+}
+
 // Init queues up the database connection
 func Init() (ok bool, err error) {
 	if databasePath == "" {

--- a/internal/pkg/gifkv/gifkv_test.go
+++ b/internal/pkg/gifkv/gifkv_test.go
@@ -193,6 +193,12 @@ func TestGifRecordMarkdown(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("![%v](%v)", record.BaseName, record.URL()), record.Markdown())
 }
 
+func TestGifRecordBBCode(t *testing.T) {
+	record := generateRecord("1989", "swift")
+
+	assert.Equal(t, fmt.Sprintf("[img]%v[/img]", record.URL()), record.BBCode())
+}
+
 func TestGifRecordRemoteOK(t *testing.T) {
 	record := generateRecord("1989", "swift")
 

--- a/internal/pkg/version/version.go
+++ b/internal/pkg/version/version.go
@@ -11,9 +11,9 @@ const (
 	// Major version
 	Major = 1
 	// Minor version
-	Minor = 4
+	Minor = 5
 	// Patch version
-	Patch = 1
+	Patch = 0
 	// ReleaseCandidate version of the library
 	ReleaseCandidate = 0
 )

--- a/internal/pkg/version/version_test.go
+++ b/internal/pkg/version/version_test.go
@@ -13,7 +13,7 @@ func TestLibrary(t *testing.T) {
 }
 
 func TestCurrent(t *testing.T) {
-	assert.Equal(t, "1.4.1", Current())
+	assert.Equal(t, "1.5.0", Current())
 }
 
 func TestFullVersion(t *testing.T) {


### PR DESCRIPTION
New `bbcode` and `b` commands to switch to `bbcode` mode, which will provide `[img]{url}[/img]` output.

![mabel - gravity falls.gif](https://dl.dropboxusercontent.com/s/i68ajwmyyfhg2qm/mabel+-+gravity+falls.gif)