### PR TITLE
BBCode Startup Support

### DIFF
--- a/cmd/dropbox-gif-linker/dropbox-gif-linker.go
+++ b/cmd/dropbox-gif-linker/dropbox-gif-linker.go
@@ -47,6 +47,10 @@ func handleFirstArg(argument string) {
 	if os.Args[1] == "url" {
 		mode = "url"
 	}
+
+	if os.Args[1] == "b" || os.Args[1] == "bbcode" {
+		mode = "bbcode"
+	}
 }
 
 func init() {

--- a/internal/pkg/version/version.go
+++ b/internal/pkg/version/version.go
@@ -13,7 +13,7 @@ const (
 	// Minor version
 	Minor = 5
 	// Patch version
-	Patch = 0
+	Patch = 1
 	// ReleaseCandidate version of the library
 	ReleaseCandidate = 0
 )

--- a/internal/pkg/version/version_test.go
+++ b/internal/pkg/version/version_test.go
@@ -13,7 +13,7 @@ func TestLibrary(t *testing.T) {
 }
 
 func TestCurrent(t *testing.T) {
-	assert.Equal(t, "1.5.0", Current())
+	assert.Equal(t, "1.5.1", Current())
 }
 
 func TestFullVersion(t *testing.T) {


### PR DESCRIPTION
Support for:

`dropbox-gif-linker bbcode` and `dropbox-gif-linker b` to enter `bbcode` mode on startup.

![stan - southpark.gif](https://dl.dropboxusercontent.com/s/uut8kufv2t0d5wy/stan+-+southpark.gif)